### PR TITLE
implements $CDPATH

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,5 +1,7 @@
 # Add `~/bin` to the `$PATH`
 export PATH="$HOME/bin:$PATH";
+# cd directly into any $HOME directory from any current directory
+export CDPATH=".:$HOME'
 
 # Load the shell dotfiles, and then some:
 # * ~/.path can be used to extend `$PATH`.


### PR DESCRIPTION
`cd` will search all directories listed in `CDPATH` and jump to the first directory it finds in the order listed. The default setting is `CDPATH=.` which results in `cd` only searching the current working directory.

Added `$HOME` path to enhance `cd` enabling the ability to jump directly to any directory below the current directory, as well as the home directory.